### PR TITLE
Downsample tests

### DIFF
--- a/notebooks/working_with_objects.ipynb
+++ b/notebooks/working_with_objects.ipynb
@@ -231,6 +231,7 @@
     "# Request the pixel values of the entire labeled image. Pixel values will be created as they are requested \n",
     "label_image = labeled_server.read_region()\n",
     "\n",
+    "\n",
     "# label_image is an image of shape (c, y, x), not easily plottable\n",
     "# We use a utility function from qubalab to plot the image\n",
     "from qubalab.display.plot import plotImage\n",
@@ -497,7 +498,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.6"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/qubalab/images/image_server.py
+++ b/qubalab/images/image_server.py
@@ -70,7 +70,6 @@ class ImageServer(ABC):
                  pixel located at coordinates [x, y] on the image
         :raises ValueError: when the region to read is not specified
         """
-
         if region is None:
             region = Region2D(x=x, y=y, width=width, height=height, z=z, t=t)
         elif isinstance(region, tuple):

--- a/qubalab/images/labeled_server.py
+++ b/qubalab/images/labeled_server.py
@@ -106,7 +106,7 @@ class LabeledImageServer(ImageServer):
                         draw_geometry(
                             image.size,
                             drawing_context,
-                            self._geometries[i],
+                            shapely.affinity.translate(self._geometries[i], -region.x, -region.y),
                             1
                         )
                 full_image[label, :, :] = np.asarray(image, dtype=self.metadata.dtype)
@@ -119,7 +119,7 @@ class LabeledImageServer(ImageServer):
                 draw_geometry(
                     image.size,
                     drawing_context,
-                    self._geometries[i],
+                    shapely.affinity.translate(self._geometries[i], -region.x, -region.y),
                     self._feature_index_to_label[i]
                 )
             return np.expand_dims(np.asarray(image, dtype=self.metadata.dtype), axis=0)

--- a/qubalab/images/labeled_server.py
+++ b/qubalab/images/labeled_server.py
@@ -34,7 +34,7 @@ class LabeledImageServer(ImageServer):
         """
         :param base_image_metadata: the metadata of the image containing the image features
         :param features: the image features to draw
-        :param label_map: a dictionnary mapping a classification to a label. The value of pixels where an image feature with
+        :param label_map: a dictionary mapping a classification to a label. The value of pixels where an image feature with
                           a certain classification is present will be taken from this dictionnary. If not provided, each feature
                           will be assigned a unique integer. All labels must be greater than 0 
         :param downsample: the downsample to apply to the image. Can be omitted to use the full resolution image
@@ -88,7 +88,7 @@ class LabeledImageServer(ImageServer):
                 self._base_image_metadata.pixel_calibration.length_z
             ),
             False,
-            bool if self._multichannel else np.uint
+            bool if self._multichannel else np.uint32
         )
 
     def _read_block(self, level: int, region: Region2D) -> np.ndarray:
@@ -113,9 +113,8 @@ class LabeledImageServer(ImageServer):
 
             return full_image
         else:
-            image = PIL.Image.new('P', (region.width, region.height))
+            image = PIL.Image.new('I', (region.width, region.height))
             drawing_context = PIL.ImageDraw.Draw(image)
-
             for i in self._tree.query(region.geometry):
                 draw_geometry(
                     image.size,
@@ -123,5 +122,4 @@ class LabeledImageServer(ImageServer):
                     self._geometries[i],
                     self._feature_index_to_label[i]
                 )
-
             return np.expand_dims(np.asarray(image, dtype=self.metadata.dtype), axis=0)

--- a/tests/images/test_labeled_server.py
+++ b/tests/images/test_labeled_server.py
@@ -183,7 +183,7 @@ def test_x_pixel_length_with_no_downsample():
 
 
 def test_dtype_when_not_multi_channel():
-    expected_dtype = np.uint
+    expected_dtype = np.uint32
     labeled_server = LabeledImageServer(sample_metadata, [], multichannel=False)
 
     dtype = labeled_server.metadata.dtype
@@ -381,3 +381,13 @@ def test_read_polygon_in_single_channel_image_without_label_map_with_downsample(
     image = labeled_server.read_region(1, Region2D(0, 0, labeled_server.metadata.width, labeled_server.metadata.height))
 
     np.testing.assert_array_equal(image, expected_image)
+
+def test_label_can_hold_many_values():
+    downsample = 2
+    n_objects = 1000
+    features = [ImageFeature(geojson.Polygon([[(6, 2), (8, 2), (8, 4), (4, 4)]]), Classification("Some classification")) for i in range(n_objects)]
+    labeled_server = LabeledImageServer(sample_metadata, features, multichannel=False, downsample=downsample)
+
+    image = labeled_server.read_region(1, Region2D(0, 0, labeled_server.metadata.width, labeled_server.metadata.height))
+
+    assert np.max(image), n_objects

--- a/tests/images/test_labeled_server.py
+++ b/tests/images/test_labeled_server.py
@@ -465,17 +465,16 @@ def test_multi_channel_labeled_image_with_region_request():
     downsample = 1
     features = [ImageFeature(geojson.LineString([(7, 5), (9, 5)]))]
     expected_image = np.array(
-        [[[[False, False, False, False, False],
+        [[[False, False, False, False, False],
           [False, False, False, False, False],
-          [False, False, False, False, False]]],
-          [[[False, False, False, False, False],
+          [False, False, False, False, False]],
+          [[False, False, False, False, False],
           [False, False, False, False, False],
-          [False, False, True, True, True]]]]
+          [False, False, True, True, True]]]
     )
     labeled_server = LabeledImageServer(sample_metadata, features, multichannel=True, downsample=downsample)
     region = Region2D(5, 3, labeled_server.metadata.width-5, labeled_server.metadata.height-3)
     image = labeled_server.read_region(1, region)
-
     np.testing.assert_array_equal(image, expected_image)
 
 def test_multi_channel_labeled_image_with_starting_downsample():

--- a/tests/images/test_labeled_server.py
+++ b/tests/images/test_labeled_server.py
@@ -24,7 +24,7 @@ sample_metadata = ImageMetadata(
 large_metadata = ImageMetadata(
     "/path/to/img.tiff",
     "Image name",
-    (ImageShape(1000, 500),),
+    (ImageShape(500, 250),),
     PixelCalibration(
         PixelLength.create_microns(2.5),
         PixelLength.create_microns(2.5)
@@ -397,16 +397,19 @@ def test_read_polygon_in_single_channel_image_without_label_map_with_downsample(
 
 def test_label_can_hold_many_values():
     downsample = 1
-    max_objects = 500
-    random.seed(42)
+    max_objects = 1000
+    random.seed(1)
     def rands():
+        x = random.randint(0, int(large_metadata.shape.x / downsample))
+        y = random.randint(0, int(large_metadata.shape.x / downsample))
         return (
-            random.randint(0, int(sample_metadata.shape.x / downsample)),
-            random.randint(0, int(sample_metadata.shape.y / downsample))
+            (x, y),
+            (x + 1, y),
+            (x + 1, y + 1),
+            (x, y + 1)
         )
     
-    coords = [(rands(), rands(), rands(), rands()) for i in range(max_objects)]
-    coords = list(set(coords))
+    coords = [rands() for i in range(max_objects)]
 
     n_objects = len(coords)
     features = [ImageFeature(geojson.Polygon([coords[i]]), Classification("Some classification")) for i in range(n_objects)]
@@ -414,7 +417,7 @@ def test_label_can_hold_many_values():
 
     image = labeled_server.read_region(1, Region2D(0, 0, labeled_server.metadata.width, labeled_server.metadata.height))
 
-    assert np.max(image) > 255
+    assert np.max(image) == max_objects
 
 
 def test_single_channel_labeled_image_with_region_request():

--- a/tests/images/test_labeled_server.py
+++ b/tests/images/test_labeled_server.py
@@ -415,3 +415,99 @@ def test_label_can_hold_many_values():
     image = labeled_server.read_region(1, Region2D(0, 0, labeled_server.metadata.width, labeled_server.metadata.height))
 
     assert np.max(image) > 255
+
+
+def test_single_channel_labeled_image_with_region_request():
+    downsample = 1
+    features = [ImageFeature(geojson.LineString([(7, 5), (9, 5)]))]
+    expected_image = np.array(
+        [[[0, 0, 0, 0, 0],
+          [0, 0, 0, 0, 0],
+          [0, 0, 1, 1, 1]]]
+    )
+    labeled_server = LabeledImageServer(sample_metadata, features, multichannel=False, downsample=downsample)
+    region = Region2D(5, 3, labeled_server.metadata.width-5, labeled_server.metadata.height-3)
+    image = labeled_server.read_region(1, region)
+
+    np.testing.assert_array_equal(image, expected_image)
+
+def test_single_channel_labeled_image_with_starting_downsample():
+    features = [ImageFeature(geojson.LineString([(6, 5), (9, 5)]))]
+    expected_image = np.array(
+        [[[0, 0, 0, 0, 0],
+          [0, 0, 0, 0, 0],
+          [0, 0, 0, 1, 1]]]
+    )
+    labeled_server = LabeledImageServer(sample_metadata, features, multichannel=False, downsample=1)
+    downsample = 2
+    region = Region2D(0, 0, labeled_server.metadata.width, labeled_server.metadata.height)
+    image = labeled_server.read_region(downsample, region)
+
+    np.testing.assert_array_equal(image, expected_image)
+
+
+def test_single_channel_labeled_image_with_request_downsample():
+    features = [ImageFeature(geojson.LineString([(6, 5), (9, 5)]))]
+    expected_image = np.array(
+        [[[0, 0, 0, 0, 0],
+          [0, 0, 0, 0, 0],
+          [0, 0, 0, 1, 1]]]
+    )
+    downsample = 2
+    labeled_server = LabeledImageServer(sample_metadata, features, multichannel=False, downsample=downsample)
+    region = Region2D(0, 0, labeled_server.metadata.width, labeled_server.metadata.height)
+    image = labeled_server.read_region(1, region)
+
+    np.testing.assert_array_equal(image, expected_image)
+
+
+def test_multi_channel_labeled_image_with_region_request():
+    downsample = 1
+    features = [ImageFeature(geojson.LineString([(7, 5), (9, 5)]))]
+    expected_image = np.array(
+        [[[[False, False, False, False, False],
+          [False, False, False, False, False],
+          [False, False, False, False, False]]],
+          [[[False, False, False, False, False],
+          [False, False, False, False, False],
+          [False, False, True, True, True]]]]
+    )
+    labeled_server = LabeledImageServer(sample_metadata, features, multichannel=True, downsample=downsample)
+    region = Region2D(5, 3, labeled_server.metadata.width-5, labeled_server.metadata.height-3)
+    image = labeled_server.read_region(1, region)
+
+    np.testing.assert_array_equal(image, expected_image)
+
+def test_multi_channel_labeled_image_with_starting_downsample():
+    features = [ImageFeature(geojson.LineString([(6, 5), (9, 5)]))]
+    expected_image = np.array(
+        [[[False, False, False, False, False],
+          [False, False, False, False, False],
+          [False, False, False, False, False]],
+          [[False, False, False, False, False],
+          [False, False, False, False, False],
+          [False, False, False, True, True]]]
+    )
+    downsample = 2
+    labeled_server = LabeledImageServer(sample_metadata, features, multichannel=True, downsample=downsample)
+    region = Region2D(0, 0, labeled_server.metadata.width, labeled_server.metadata.height)
+    image = labeled_server.read_region(1, region)
+
+    np.testing.assert_array_equal(image, expected_image)
+
+def test_multi_channel_labeled_image_with_request_downsample():
+    features = [ImageFeature(geojson.LineString([(6, 5), (9, 5)]))]
+    expected_image = np.array(
+        [[[False, False, False, False, False],
+          [False, False, False, False, False],
+          [False, False, False, False, False]],
+          [[False, False, False, False, False],
+          [False, False, False, False, False],
+          [False, False, False, True, True]]]
+    )
+    labeled_server = LabeledImageServer(sample_metadata, features, multichannel=True, downsample=1)
+    downsample = 2
+    region = Region2D(0, 0, labeled_server.metadata.width, labeled_server.metadata.height)
+    image = labeled_server.read_region(downsample, region)
+
+    np.testing.assert_array_equal(image, expected_image)


### PR DESCRIPTION
I maintain this is bad and/or wrong but I'm not going to continue arguing the point, so will leave these tests here for my own future reference

Downsampling

The current behaviour is arguably unintuitive with respect to downsampling as demonstrated in the other 4 unit tests added. There is some discussion in #25 about whether this behaviour should change. In my view, if retaining the current behaviour, we should warn users (either in code or documentation but ideally both) that they may be receiving rasterised images, and that they should be supplying coordinates based on the downsampled image, rather than the full-sized image that the labeled image server is created from.